### PR TITLE
use defer instead of async, so scripts still run in order

### DIFF
--- a/scout_manager/templates/scout_manager/include/head.html
+++ b/scout_manager/templates/scout_manager/include/head.html
@@ -78,17 +78,17 @@
 
 <!-- javascript -->
 {% compress js %}
-<script async="async" src="{% static 'vendor/js/jquery-1.11.0.min.js' %}"></script>
-<script async="async" src="{% static 'vendor/js/js-cookie-2.1.1.js' %}"></script>
-<script async="async" src="{% static 'vendor/js/bootstrap-3.3.6.min.js' %}"></script>
-<script async="async" src="{% static 'vendor/js/bootstrap-validator-0.11.5.min.js' %}"></script>
-<script async="async" src="{% static 'vendor/js/jquery.dataTables.min.js' %}"></script>
-<script async="async" src="{% static 'scout_manager/js/forms.js' %}"></script>
-<script async="async" src="{% static 'scout_manager/js/maps.js' %}"></script>
-<script async="async" src="{% static 'scout_manager/js/web.js' %}"></script>
-<script async="async" src="{% static 'scout_manager/js/spot.js' %}"></script>
-<script async="async" src="{% static 'scout_manager/js/item.js' %}"></script>
-<script async="async" src="{% static 'scout_manager/js/list.js' %}"></script>
+<script defer="defer" src="{% static 'vendor/js/jquery-1.11.0.min.js' %}"></script>
+<script defer="defer" src="{% static 'vendor/js/js-cookie-2.1.1.js' %}"></script>
+<script defer="defer" src="{% static 'vendor/js/bootstrap-3.3.6.min.js' %}"></script>
+<script defer="defer" src="{% static 'vendor/js/bootstrap-validator-0.11.5.min.js' %}"></script>
+<script defer="defer" src="{% static 'vendor/js/jquery.dataTables.min.js' %}"></script>
+<script defer="defer" src="{% static 'scout_manager/js/forms.js' %}"></script>
+<script defer="defer" src="{% static 'scout_manager/js/maps.js' %}"></script>
+<script defer="defer" src="{% static 'scout_manager/js/web.js' %}"></script>
+<script defer="defer" src="{% static 'scout_manager/js/spot.js' %}"></script>
+<script defer="defer" src="{% static 'scout_manager/js/item.js' %}"></script>
+<script defer="defer" src="{% static 'scout_manager/js/list.js' %}"></script>
 {% endcompress %}
 
 <!-- googlme maps -->


### PR DESCRIPTION
When I set COMPRESS_ENABLED = False, for debugging, the scripts usually end up being loaded out of order, and failing, because of the async attribute. By using defer, they are all loaded in order after the rest of the page loads.
