### PR TITLE
Display columns for STF (Yes/No) and Status (Published/Draft) in item…

### DIFF
--- a/scout_manager/dao/space.py
+++ b/scout_manager/dao/space.py
@@ -2,6 +2,7 @@ from spotseeker_restclient.spotseeker import Spotseeker
 from spotseeker_restclient.exceptions import DataFailureException
 from scout.dao.space import add_cuisine_names, add_foodtype_names_to_spot, \
     add_payment_names, add_additional_info, add_study_info
+from scout.dao.item import add_item_info
 from scout_manager.dao.groups import add_group
 import json
 import re
@@ -37,6 +38,7 @@ def _get_spots_by_app_type(app_type, filters, published):
         spots = spot_client.search_spots(filters)
         for spot in spots:
             spot = process_extended_info(spot)
+            spot = add_item_info(spot)
             # If we want only published spots, check is_hidden attribute
             if published:
                 # This is a string value rather than proper boolean.
@@ -80,7 +82,9 @@ def _get_all_spots(filters):
 def get_spot_by_id(spot_id):
     spot_client = Spotseeker()
     res = spot_client.get_spot_by_id(spot_id)
-    return process_extended_info(res)
+    spot = process_extended_info(res)
+    spot = add_item_info(spot)
+    return spot
 
 
 def process_extended_info(spot):

--- a/scout_manager/templates/scout_manager/include/spaces_add_edit.html
+++ b/scout_manager/templates/scout_manager/include/spaces_add_edit.html
@@ -286,16 +286,8 @@
                     <td><a href="/manager/items/{{ item.item_id }}/" title="See details: {{ item.name }}">{{ item.name }}</a></td>
                     <td>{{ item.category }}</td>
                     <td>{{ item.subcategory }}</td>
-                    <td>
-                        {% for ei in item.extended_info %}
-                             {% if ei.key == "i_is_stf" %}{{ ei.value }}{% endif %}
-                        {% endfor %}
-                    </td>
-                    <td>
-                        {% for ei in item.extended_info %}
-                             {% if ei.key == "i_is_active" %}{{ ei.value }}{% endif %}
-                        {% endfor %}
-                    </td>
+                    <td>{% if item.is_stf %}Yes{% else %}No{% endif %}</td>
+                    <td>{% if item.is_active %}Published{% else %}<span class="status-draft">Draft</span>{% endif %}</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/scout_manager/templates/scout_manager/items.html
+++ b/scout_manager/templates/scout_manager/items.html
@@ -41,16 +41,8 @@
                 <td>{{ spot.name }}</td>
                 <td>{{ spot.campus }}</td>
                 <td>{{ spot.building_name }}</td>
-                <td>
-                    {% for ei in item.extended_info %}
-                         {% if ei.key == "i_is_stf" %}{{ ei.value }}{% endif %}
-                    {% endfor %}
-                </td>
-                <td>
-                    {% for ei in item.extended_info %}
-                         {% if ei.key == "i_is_active" %}{{ ei.value }}{% endif %}
-                    {% endfor %}
-                </td>
+                <td>{% if item.is_stf %}Yes{% else %}No{% endif %}</td>
+                <td>{% if item.is_active %}Published{% else %}<span class="status-draft">Draft</span>{% endif %}</td>
             </tr>
             {% endfor %}
 


### PR DESCRIPTION
… listings

item.is_active and item.is_stf aren't populated unless the spot is run through add_item_info() first. This does that where needed and uses a simple if/else in the templates.  

Won't give accurate info for CTE items until https://github.com/uw-it-aca/spacescout_labstats/pull/34 is implemented.

