### PR TITLE
SCOUT-738: Improving Error Messages in API.py, Fix Travis, Update ReadMe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - python manage.py migrate --noinput
   - npm install mocha
   - npm install jquery
-  - npm install jsdom@3
+  - npm install jsdom
 script:
   - pep8 scout_manager/ --exclude=migrations,scout_manager/test
   - coverage run --source=scout_manager/ --omit=scout_manager/migrations/* manage.py test scout_manager

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ This README documents whatever steps are necessary to get your application up an
 
 
     MANAGER_SUPERUSER_GROUP = 'u_acadev_tester' (or another mock group you define)
+    
+    OAUTH_USER = 'scout_manager' (matching a SPOTSEEKER_AUTH_ADMIN setting in spotseeker-server)
+
+
+**Note: If you haven't already, remember to add details for a connection to spotseeker_server in your settings.py. Change 'File' to 'Live' if you want to connect to a live spotseeker_server:**
+    
+    SPOTSEEKER_HOST = ''
+    SPOTSEEKER_OAUTH_KEY = ''
+    SPOTSEEKER_OAUTH_SECRET = ''
+    SPOTSEEKER_DAO_CLASS = 'spotseeker_restclient.dao_implementation.spotseeker.File'
 
 **Run with defined remote user, javerage will work with mock groups**
 


### PR DESCRIPTION
<a href="https://jira.cac.washington.edu/browse/SCOUT-738"> SCOUT-738 </a>

I had trouble getting my scout-manager build running (forgot to include `OAUTH_USER` in my settings.py) so these fixes would hopefully help out the next person debug where the error is coming from.
- Using `ex.message` instead of `ex.msg`
- Checking for `ImproperlyConfigured` errors (when settings.py is configured improperly) and returning the appropriate `500` status code (rather than a `400`)
- Logger wasn't logging so added `logger.basicConfig()`
- Updated ReadMe to mention use of this `OAUTH_USER` setting

Also...
- Updated jsdom so travis would pass again