### PR TITLE
Bug/scout 496

### DIFF
--- a/scout_manager/static/scout_manager/js/maps.js
+++ b/scout_manager/static/scout_manager/js/maps.js
@@ -38,6 +38,7 @@ var Maps = {
                         marker = null;
                         $("#space_latitude").val("");
                         $("#space_longitude").val("");
+                        Forms.init_validate();
                     });
                 }
 

--- a/scout_manager/static/scout_manager/js/maps.js
+++ b/scout_manager/static/scout_manager/js/maps.js
@@ -31,6 +31,14 @@ var Maps = {
                     google.maps.event.addListener(marker, 'drag', function(e) {
                         setLatLongValue(e.latLng);
                     });
+
+                    //clear the location when the campus is changed
+                    $("#campus_select").change(function(e) {
+                        marker.setMap(null);
+                        marker = null;
+                        $("#space_latitude").val("");
+                        $("#space_longitude").val("");
+                    });
                 }
 
                 setLatLongValue(latlng);


### PR DESCRIPTION
Clear google maps marker, latitude, and longitude, on campus change. Implemented as a closure in the setMarker function because google maps doesn't have a way to retrieve references to Markers once they're set.