### PR TITLE
Client no longer deletes the image div

### DIFF
--- a/scout_manager/static/scout_manager/js/forms.js
+++ b/scout_manager/static/scout_manager/js/forms.js
@@ -219,7 +219,6 @@ var Forms = {
                 window.removed_images = [{id: image_id,
                                           etag: image_etag}];
             }
-            $(this).parent().parent("div").remove();
             Forms.image_check_count();
 
             // reload spot after image delete
@@ -240,7 +239,6 @@ var Forms = {
                 window.removed_images = [{id: image_id,
                                           etag: image_etag}];
             }
-            $(this).parent().parent("div").remove();
             Forms.image_check_count();
 
             Item.submit_item();


### PR DESCRIPTION
If the User does not have permission to delete an image it will no longer disappear on the client. If the user does have permission, the image will be gone when the page reloads (assuming the fix to scout manager's cache invalidation has been implemented)