### PR TITLE
Raise 404 when visiting spot that doesn't exist

### DIFF
--- a/scout_manager/test/url_responses_test.py
+++ b/scout_manager/test/url_responses_test.py
@@ -24,6 +24,7 @@ _testCases = (
     ('Spaces add', '/spaces/add/', OK, 'SCOUT-122'),
     ('Spaces add redir', '/spaces/add', redir, 'SCOUT-129'),
     ('Spaces specific', '/spaces/2/', OK, 'SCOUT-122'),
+    ('Spaces specific nonexistant', '/spaces/0/', notfound),
     ('Spaces specific redir', '/spaces/5070', redir, 'SCOUT-129'),
     ('Bad url', '/rando/', notfound)
 )

--- a/scout_manager/views/pages.py
+++ b/scout_manager/views/pages.py
@@ -6,6 +6,7 @@ from scout_manager.dao.space import get_spot_hours_by_day, get_spot_list
 from scout_manager.dao.buildings import get_building_list
 from scout_manager.dao.groups import is_superuser
 from scout_manager.models import GroupMembership
+from spotseeker_restclient.exceptions import DataFailureException
 from scout.dao.image import get_spot_image, get_item_image
 from scout.dao.item import get_filtered_items, get_item_count
 from scout.views import CAMPUS_LOCATIONS
@@ -17,9 +18,9 @@ import base64
 def home(request):
     netid = UserService().get_user()
     return render_to_response(
-            'scout_manager/home.html',
-            {"netid": netid},
-            context_instance=RequestContext(request))
+        'scout_manager/home.html',
+        {"netid": netid},
+        context_instance=RequestContext(request))
 
 
 def items(request):
@@ -48,9 +49,9 @@ def items_add(request):
                "buildings": buildings,
                "netid": netid}
     return render_to_response(
-            'scout_manager/items_add.html',
-            context,
-            context_instance=RequestContext(request))
+        'scout_manager/items_add.html',
+        context,
+        context_instance=RequestContext(request))
 
 
 def items_edit(request, item_id):
@@ -71,9 +72,9 @@ def schedule(request, spot_id):
     context = {"spot": spot,
                "netid": netid}
     return render_to_response(
-            'scout_manager/schedule.html',
-            context,
-            context_instance=RequestContext(request))
+        'scout_manager/schedule.html',
+        context,
+        context_instance=RequestContext(request))
 
 
 def spaces(request):
@@ -95,9 +96,9 @@ def spaces(request):
                "netid": netid,
                "is_superuser": is_superuser(netid)}
     return render_to_response(
-            'scout_manager/spaces.html',
-            context,
-            context_instance=RequestContext(request))
+        'scout_manager/spaces.html',
+        context,
+        context_instance=RequestContext(request))
 
 
 def spaces_add(request):
@@ -108,22 +109,29 @@ def spaces_add(request):
                "campus_locations": CAMPUS_LOCATIONS,
                "netid": netid}
     return render_to_response(
-            'scout_manager/spaces_add.html',
-            context,
-            context_instance=RequestContext(request))
+        'scout_manager/spaces_add.html',
+        context,
+        context_instance=RequestContext(request))
 
 
 def spaces_upload(request):
     netid = UserService().get_user()
     return render_to_response(
-            'scout_manager/spaces_upload.html',
-            {"netid": netid},
-            context_instance=RequestContext(request))
+        'scout_manager/spaces_upload.html',
+        {"netid": netid},
+        context_instance=RequestContext(request))
 
 
 def spaces_edit(request, spot_id):
     netid = UserService().get_user()
-    spot = manager_get_spot_by_id(spot_id)
+
+    try:
+        spot = manager_get_spot_by_id(spot_id)
+    except DataFailureException as e:
+        if e.status == 404:
+            raise Http404()
+        else:
+            raise e
     buildings = get_building_list()
     # if no campus buildings, get all
     if len(buildings) < 1:
@@ -134,9 +142,9 @@ def spaces_edit(request, spot_id):
                "netid": netid
                }
     return render_to_response(
-            'scout_manager/spaces_edit.html',
-            context,
-            context_instance=RequestContext(request))
+        'scout_manager/spaces_edit.html',
+        context,
+        context_instance=RequestContext(request))
 
 
 def image(request, image_id, spot_id):


### PR DESCRIPTION
Raises a 404 on the spaces edit page if it receives on from spotseeker server. Added a unit test, it assumes '/spot/0/' doesn't exist. Also fixed indents that pep8 was complaining about.