### PR TITLE
Navigate to spot list beforeblanking page

### DIFF
--- a/scout_manager/static/scout_manager/js/spot.js
+++ b/scout_manager/static/scout_manager/js/spot.js
@@ -80,8 +80,8 @@ var Spot = {
                 $("#pub_error").html("All changes have been saved.");
 
                 // reload the page
-                $("#submit_form").html("");
                 Spot._spot_post_submit(will_exit);
+                $("#submit_form").html("");
             },
             error: function(xhr, status, error) {
                 $("#pub_error").removeClass("hidden");


### PR DESCRIPTION
the _navigate_to_apptype function depends on reding the html, so it has to be done before we blank the form