### PR TITLE
Target cpu and about 80% memory

### DIFF
--- a/docker/test-values.yml
+++ b/docker/test-values.yml
@@ -1,3 +1,7 @@
+resources:
+  requests:
+    cpu: 90m
+    memory: 192Mi
 ingress:
   enabled: true
   tls:


### PR DESCRIPTION
Superuser requests cause HPA scaling on single load of all spots